### PR TITLE
Adding multi-threading to convert script

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -2,6 +2,8 @@ import os
 import argparse
 import cv2
 import numpy as np
+import queue
+import _thread
 
 def saveImage(img,path,filename):
 	if(args.file_extension == "png"):
@@ -33,13 +35,35 @@ def parse_args():
     parser.add_argument('--verbose', action='store_true',
         help='Print progress to console.')
 
+    parser.add_argument('-j' '--jobs', type=int,
+        default=1,
+        help='The number of threads to use. (default: %(default)s)')
+
     args = parser.parse_args()
     return args
+
+def threadRunner(threadName):
+    while(not q.empty()):
+        filename = q.get()
+        convertImage(threadName, filename)
+
+def convertImage(threadName, filename):
+    file_path = os.path.join(rootDir, filename)
+    if(args.verbose): print('(%s) processing\t- file %s (full path: %s)' % (threadName, filename, file_path))
+            
+    img = cv2.imread(file_path)
+
+    if hasattr(img, 'copy'):
+        processImage(img,os.path.splitext(filename)[0])
+    
 
 def main():
     global args
     global inter
+    global q
+    global rootDir
     args = parse_args()
+    q = queue.Queue()
 
     os.environ['OPENCV_IO_ENABLE_JASPER']= "true"
     inter = cv2.INTER_CUBIC
@@ -48,26 +72,34 @@ def main():
         print("Processing folder: " + args.input_folder)
     else:
         print("Not a working input_folder path: " + args.input_folder)
-        return;
+        return
 
     if not os.path.exists(args.output_folder):
         os.makedirs(args.output_folder)
 
     for root, subdirs, files in os.walk(args.input_folder):
         if(args.verbose): print('--\nroot = ' + root)
+        rootDir = root
 
         for subdir in subdirs:
             if(args.verbose): print('\t- subdirectory ' + subdir)
 
         for filename in files:
-            file_path = os.path.join(root, filename)
-            if(args.verbose): print('\t- file %s (full path: %s)' % (filename, file_path))
+            # add files to queue
+            q.put(filename)
             
-            img = cv2.imread(file_path)
+    # start threads
+    for i in range(args.j__jobs):
+        try:
+            threadName = 'thread-' + str(i)
+            if(args.verbose): print('starting thread %s' % (threadName))
+            _thread.start_new_thread(threadRunner, (threadName,))
+        except:
+            print("error! unable to start thread.")
 
-            if hasattr(img, 'copy'):
-                if(args.verbose): print('processing image: ' + filename)  
-                processImage(img,os.path.splitext(filename)[0])
+    while (not q.empty()):
+        pass
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Haven't done multithreading in python before so I wanted to try it on a rather simple problem before working on adding it to some of the other scripts. Looks like python handles the locking and unlocking on it's own but I could be wrong and I could have done this wrong.

I used `-j` as the argument because that's what seems to be the standard in the unix world.

Any suggestions or improvements are welcome.

Example of the performance improvement with 1 thread vs. 4 threads (see real time):
```
(dataset-tools) [duskvirkus@fedora dataset-tools]$ time(python convert.py -i /home/duskvirkus/art/datasets/tattoo-portraits-v1)
Processing folder: /home/duskvirkus/art/datasets/tattoo-portraits-v1

real    1m21.441s
user    2m28.611s
sys     0m4.528s
(dataset-tools) [duskvirkus@fedora dataset-tools]$ time(python convert.py -i /home/duskvirkus/art/datasets/tattoo-portraits-v1 -j 4)
Processing folder: /home/duskvirkus/art/datasets/tattoo-portraits-v1

real    0m23.055s
user    1m39.943s
sys     0m5.417s
```